### PR TITLE
add esp32 to architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=This is a driver library for VS1053 MP3 Codec Breakout adapted for Espr
 paragraph=This is a driver library for VS1053 MP3 Codec Breakout adapted for Espressif ESP8266 and ESP32 boards
 category=Device Control
 url=https://github.com/baldram/ESP_VS1053_Library
-architectures=esp8266,espressif32
+architectures=esp8266,esp32,espressif32
 includes=VS1053.h


### PR DESCRIPTION
The arduino-esp32 core uses esp32 as its architecture