### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=VS1053 Library for ESP8266/ESP32
-version=1.0.9a
+version=1.0.9-a
 author=Baldram
 maintainer=Baldram <baldram+gh@gmail.com>
 sentence=This is a driver library for VS1053 MP3 Codec Breakout adapted for Espressif ESP8266 and ESP32 boards


### PR DESCRIPTION
The previous `version` value caused the Arduino IDE to display warnings:
```
Invalid version found: 1.0.9a
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format