### PR TITLE
Set the volume always.

### DIFF
--- a/src/VS1053.cpp
+++ b/src/VS1053.cpp
@@ -191,12 +191,10 @@ void VS1053::setVolume(uint8_t vol) {
     // Input value is 0..100.  100 is the loudest.
     uint16_t value; // Value to send to SCI_VOL
 
-    if (vol != curvol) {
-        curvol = vol;                         // Save for later use
-        value = map(vol, 0, 100, 0xFF, 0x00); // 0..100% to one channel
-        value = (value << 8) | value;
-        write_register(SCI_VOL, value); // Volume left and right
-    }
+    curvol = vol;                         // Save for later use
+    value = map(vol, 0, 100, 0xFF, 0x00); // 0..100% to one channel
+    value = (value << 8) | value;
+    write_register(SCI_VOL, value); // Volume left and right
 }
 
 void VS1053::setTone(uint8_t *rtone) { // Set bass/treble (4 nibbles)


### PR DESCRIPTION
This is a proposed solution for #26. The setVolume() method sets the volume always but still caches the saved value.

I wanted to get rid that ```curvol``` cache value, the returned value could be read from the chip directly, but it needs to be converted back (by a ```map``` function for example) to a range from 0 to 100. There was a side effect, when I did a small test like:
```
player.setVolume(70);
uint8_t readBack = player.getVolume();
```
then the ```readBack``` variable was set to 69. Probably this is an effect of rounding when using ```map``` method. I gave up with this solution, so in my PR the ```curvol``` is not totaly removed.