### PR TITLE
Add left and right volume balance enhancement

### DIFF
--- a/src/VS1053.h
+++ b/src/VS1053.h
@@ -44,7 +44,7 @@ private:
     uint8_t dcs_pin;                        // Pin where DCS line is connected
     uint8_t dreq_pin;                       // Pin where DREQ line is connected
     uint8_t curvol;                         // Current volume setting 0..100%
-    int8_t  curbalance;                     // Current balance setting -100..100
+    int8_t  curbalance = 0;                 // Current balance setting -100..100
                                             // (-100 = right channel silent, 100 = left channel silent)
     const uint8_t vs1053_chunk_size = 32;
     // SCI Register

--- a/src/VS1053.h
+++ b/src/VS1053.h
@@ -44,6 +44,8 @@ private:
     uint8_t dcs_pin;                        // Pin where DCS line is connected
     uint8_t dreq_pin;                       // Pin where DREQ line is connected
     uint8_t curvol;                         // Current volume setting 0..100%
+    int8_t  curbalance;                     // Current balance setting -100..100
+                                            // (-100 = right channel silent, 100 = left channel silent)
     const uint8_t vs1053_chunk_size = 32;
     // SCI Register
     const uint8_t SCI_MODE = 0x0;
@@ -127,11 +129,17 @@ public:
     // Set the player volume.Level from 0-100, higher is louder
     void setVolume(uint8_t vol);
 
+    // Adjusting the left and right volume balance, higher to enhance the right side, lower to enhance the left side.
+    void setBalance(int8_t balance);
+
     // Set the player baas/treble, 4 nibbles for treble gain/freq and bass gain/freq
     void setTone(uint8_t *rtone);
 
     // Get the currenet volume setting, higher is louder
     uint8_t getVolume();
+
+    // Get the currenet balance setting (-100..100)
+    int8_t getBalance();
 
     // Print configuration details to serial output.
     void printDetails(const char *header);


### PR DESCRIPTION
Enhancement for adjusting the left and right volume balance.
According to documentation the lowest value (total silence) for SCI_VOL is 0xFEFE (instead FFFF) so I also modify map function.
````
map(valueL, 0, 100, 0xFE, 0x00);
````