### PR TITLE
#64: Add data rate adjusting support

### DIFF
--- a/src/VS1053.cpp
+++ b/src/VS1053.cpp
@@ -350,3 +350,17 @@ void VS1053::clearDecodedTime() {
     write_register(SCI_DECODE_TIME, 0x00);
     write_register(SCI_DECODE_TIME, 0x00);
 }
+
+/**
+ * Fine tune the data rate
+ */
+void VS1053::adjustRate(long ppm2) {
+    write_register(SCI_WRAMADDR, 0x1e07);
+    write_register(SCI_WRAM, ppm2);
+    write_register(SCI_WRAM, ppm2 >> 16);
+    // oldClock4KHz = 0 forces  adjustment calculation when rate checked.
+    write_register(SCI_WRAMADDR, 0x5b1c);
+    write_register(SCI_WRAM, 0);
+    // Write to AUDATA or CLOCKF checks rate and recalculates adjustment.
+    write_register(SCI_AUDATA, read_register(SCI_AUDATA));
+}

--- a/src/VS1053.h
+++ b/src/VS1053.h
@@ -152,6 +152,9 @@ public:
         return (digitalRead(dreq_pin) == HIGH);
     }
 
+    // Fine tune the data rate
+    void adjustRate(long ppm2);
+
     // An optional switch preventing the module starting up in MIDI mode
     void switchToMp3Mode();
 
@@ -164,8 +167,9 @@ public:
     // Clears SCI_DECODE_TIME register (sets 0x00)
     void clearDecodedTime();
 
+    // A low level method for a direct data register manipulation.
     // Made public to enable loading firmware patches in user code
-    void write_register(uint8_t _reg, uint16_t _value) const;    
+    void write_register(uint8_t _reg, uint16_t _value) const;
 };
 
 #endif


### PR DESCRIPTION
Aligned to the `Edzelf/Esp-radio` parent project. 
Added the `adjustRate` method, which was probably missing at the forking time.