### PR TITLE
Add I2S output feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ Above example and self-explanatory method name tells everything. It simply provi
 
 Optionally available is also `player.clearDecodedTime()` which clears decoded time (sets `SCI_DECODE_TIME` register to `0x00`).
 
+##### Enable I2S output
+
+```
+player.enableI2sOut(/* i2sRate: optional sampling rate, default is 48kHz */);
+player.disableI2sOut();
+```
+I2S output of the VS1053 chip can be enabled/disabled using methods `enableI2sOut` and `disableI2sOut`. When enabled, the gpio lines won't be available for other purposes. On reset the I2S output is disabled. The assignment to I2S lines is according to the table below:
+
+|  VS1053 GPIO | I2S            |
+|--------------|----------------|
+| 4            | LROUT / WSEL   |
+| 5            | MCLCK          |
+| 6            | SCLK / BCLK    |
+| 7            | SDATA / DOUT   |
+
+Refer to the [VS1053 datasheet](https://www.vlsi.fi/fileadmin/datasheets/vs1053.pdf) for details: the pin assignment is specified in section 5.1 on page 12, the I2S DAC interface is described in section 11.14 on page 83.
+
 #### Logging / debugging
 
 The library uses ESP Arduino framework built in logger (Arduino core for [ESP32](https://github.com/espressif/arduino-esp32/issues/893#issuecomment-348069135) and [ESP8266](https://github.com/esp8266/Arduino/blob/master/doc/Troubleshooting/debugging.rst#debug-level)).<br /> 

--- a/src/VS1053.h
+++ b/src/VS1053.h
@@ -40,6 +40,12 @@
 
 #include "patches/vs1053b-patches.h"
 
+enum VS1053_I2S_RATE {
+    VS1053_I2S_RATE_192_KHZ,
+    VS1053_I2S_RATE_96_KHZ,
+    VS1053_I2S_RATE_48_KHZ
+};
+
 class VS1053 {
 private:
     uint8_t cs_pin;                         // Pin where CS line is connected
@@ -70,6 +76,12 @@ private:
     const uint8_t SM_TESTS = 5;             // Bitnumber in SCI_MODE for tests
     const uint8_t SM_LINE1 = 14;            // Bitnumber in SCI_MODE for Line input
     const uint8_t SM_STREAM = 6;            // Bitnumber in SCI_MODE for Streaming Mode
+
+    const uint16_t ADDR_REG_GPIO_DDR_RW = 0xc017;
+    const uint16_t ADDR_REG_GPIO_VAL_R = 0xc018;
+    const uint16_t ADDR_REG_GPIO_ODATA_RW = 0xc019;
+    const uint16_t ADDR_REG_I2S_CONFIG_RW = 0xc040;
+
     SPISettings VS1053_SPI;                 // SPI settings for this slave
     uint8_t endFillByte;                    // Byte to send when stopping song
 protected:
@@ -166,6 +178,12 @@ public:
 
     // An optional switch preventing the module starting up in MIDI mode
     void switchToMp3Mode();
+
+    // disable I2S output; this is the default state
+    void disableI2sOut();
+
+    // enable I2S output (GPIO4=LRCLK/WSEL; GPIO5=MCLK; GPIO6=SCLK/BCLK; GPIO7=SDATA/DOUT)
+    void enableI2sOut(VS1053_I2S_RATE i2sRate = VS1053_I2S_RATE_48_KHZ);
 
     // Checks whether the VS1053 chip is connected and is able to exchange data to the ESP
     bool isChipConnected();


### PR DESCRIPTION
VS1053B has builtin support for I2S output, which is disabled by default and uses GPIO4-7.

This PR adds methods to enable I2S output.