### PR TITLE
Fix compiler error in Arduino IDE 2.0.x

### DIFF
--- a/src/VS1053.cpp
+++ b/src/VS1053.cpp
@@ -297,6 +297,7 @@ void VS1053::streamModeOff() {
 void VS1053::printDetails(const char *header) {
     uint16_t regbuf[16];
     uint8_t i;
+    (void)regbuf;
 
     LOG("%s", header);
     LOG("REG   Contents\n");


### PR DESCRIPTION
Compiling stops with the following error with compiler warnings set to `All`.

`/home/cellie/Arduino/libraries/ESP_VS1053_Library/src/VS1053.cpp:298:14:error: variable 'regbuf' set but not used [-Werror=unused-but-set-variable]`