### PR TITLE
Set SCI_CLOCKF as per data sheet, add defines for clock parameters

### DIFF
--- a/src/VS1053.cpp
+++ b/src/VS1053.cpp
@@ -175,6 +175,7 @@ void VS1053::begin() {
         // Increase SC_MULT (VS1053 CLKI multiplier) first to support higher SPI rates
         writeRegister(SCI_CLOCKF, VS1053_SCI_CLOCKF);
         VS1053_SPI = SPISettings(VS1053_FAST_SCK, MSBFIRST, SPI_MODE0);
+        delay(1);
 
         writeRegister(SCI_MODE, _BV(SM_SDINEW) | _BV(SM_LINE1));
         testComm("Fast SPI, Testing VS1053 read/write registers again...\n");

--- a/src/VS1053.cpp
+++ b/src/VS1053.cpp
@@ -163,7 +163,7 @@ void VS1053::begin() {
     digitalWrite(cs_pin, HIGH);
     delay(500);
     // Init SPI in slow mode ( 0.2 MHz )
-    VS1053_SPI = SPISettings(200000, MSBFIRST, SPI_MODE0);
+    VS1053_SPI = SPISettings(VS1053_SLOW_SCK, MSBFIRST, SPI_MODE0);
     // printDetails("Right after reset/startup");
     delay(20);
     // printDetails("20 msec after reset");
@@ -171,11 +171,11 @@ void VS1053::begin() {
         //softReset();
         // Switch on the analog parts
         writeRegister(SCI_AUDATA, 44101); // 44.1kHz stereo
-        // set SC_MULT=3.5 and SC_ADD=1.0 as per datasheet recommendation (section 4.2, SCI_CLOCKF=0x8800)
-        // higher SC_MULT and resulting CLKI are needed vor VS1053 to handle higher SPI rates SCK_max = CLKI/7
-        writeRegister(SCI_CLOCKF, 0x8800);
-        // SPI Clock to 4 MHz. Now you can set high speed SPI clock.
-        VS1053_SPI = SPISettings(4000000, MSBFIRST, SPI_MODE0);
+
+        // Increase SC_MULT (VS1053 CLKI multiplier) first to support higher SPI rates
+        writeRegister(SCI_CLOCKF, VS1053_SCI_CLOCKF);
+        VS1053_SPI = SPISettings(VS1053_FAST_SCK, MSBFIRST, SPI_MODE0);
+
         writeRegister(SCI_MODE, _BV(SM_SDINEW) | _BV(SM_LINE1));
         testComm("Fast SPI, Testing VS1053 read/write registers again...\n");
         delay(10);

--- a/src/VS1053.cpp
+++ b/src/VS1053.cpp
@@ -171,8 +171,9 @@ void VS1053::begin() {
         //softReset();
         // Switch on the analog parts
         writeRegister(SCI_AUDATA, 44101); // 44.1kHz stereo
-        // The next clocksetting allows SPI clocking at 5 MHz, 4 MHz is safe then.
-        writeRegister(SCI_CLOCKF, 6 << 12); // Normal clock settings multiplyer 3.0 = 12.2 MHz
+        // set SC_MULT=3.5 and SC_ADD=1.0 as per datasheet recommendation (section 4.2, SCI_CLOCKF=0x8800)
+        // higher SC_MULT and resulting CLKI are needed vor VS1053 to handle higher SPI rates SCK_max = CLKI/7
+        writeRegister(SCI_CLOCKF, 0x8800);
         // SPI Clock to 4 MHz. Now you can set high speed SPI clock.
         VS1053_SPI = SPISettings(4000000, MSBFIRST, SPI_MODE0);
         writeRegister(SCI_MODE, _BV(SM_SDINEW) | _BV(SM_LINE1));

--- a/src/VS1053.h
+++ b/src/VS1053.h
@@ -40,6 +40,21 @@
 
 #include "patches/vs1053b-patches.h"
 
+#ifndef VS1053_SCI_CLOCKF
+// set SCI_CLOCKF=0x8800 (SC_MULT=3.5, SC_ADD=1.0) as per datasheet recommendation (section 4.2)
+// increased SC_MULT and resulting CLKI are needed vor VS1053 to handle higher SPI rates: SCK_max = CLKI/7
+#define VS1053_SCI_CLOCKF 0x8800
+#endif
+
+#ifndef VS1053_SLOW_SCK
+#define VS1053_SLOW_SCK 200000
+#endif
+
+#ifndef VS1053_FAST_SCK
+// take care to set VS1053_SCI_CLOCKF accordingly
+#define VS1053_FAST_SCK 4000000
+#endif
+
 enum VS1053_I2S_RATE {
     VS1053_I2S_RATE_192_KHZ,
     VS1053_I2S_RATE_96_KHZ,


### PR DESCRIPTION
This PR changes the SCI_CLOCKF register configuration to match the data sheet recommendations (section 4.2, SCI_CLOCKF=0x8800).

Also defines for associated clock parameters (SCI_CLOCKF, SLOW_SCK, FAST_SCK) are added.